### PR TITLE
Incorrect use of UserDataLength for GSM7 Deliver

### DIFF
--- a/sms/sms.go
+++ b/sms/sms.go
@@ -269,7 +269,6 @@ func (s *Message) PDU() (int, []byte, error) {
 			return 0, nil, ErrUnknownEncoding
 		}
 
-		sms.UserDataLength = byte(len(userData))
 		sms.UserData = userData
 		n, err := buf.Write(sms.Bytes())
 		if err != nil {


### PR DESCRIPTION
UserDataLength is already defined in line 264 and 267.