### PR TITLE
Incorrect calculation of pdu datetime

### DIFF
--- a/pdu/semi_octet.go
+++ b/pdu/semi_octet.go
@@ -2,6 +2,25 @@ package pdu
 
 import "fmt"
 
+// Swap semi-octets in octet
+func Swap(octet byte) byte {
+	return (octet << 4) | (octet >> 4 & 0x0F)
+}
+
+// Encode to semi-octets
+func Encode(value int) byte {
+	lo := byte(value % 10)
+	hi := byte((value % 100) / 10)
+	return hi<<4 | lo
+}
+
+// Decode form semi-octets
+func Decode(octet byte) int {
+	lo := octet & 0x0F
+	hi := octet >> 4 & 0x0F
+	return int(hi)*10 + int(lo)
+}
+
 // EncodeSemi packs the given numerical chunks in a semi-octet
 // representation as described in 3GPP TS 23.040.
 func EncodeSemi(chunks ...uint64) []byte {

--- a/sms/sms.go
+++ b/sms/sms.go
@@ -158,31 +158,70 @@ func (v *ValidityPeriod) ReadFrom(oct byte) {
 // Timestamp represents message's timestamp.
 type Timestamp time.Time
 
+// GSM 03.**
+// TP-Service-Centre-Time-Stamp (TP-SCTS)
+//
+//  |              | Year | Month | Day | Hour | Minute | Second | Time Zone |
+//  |--------------|------|-------|-----|------|--------|--------|-----------|
+//  |  Semi-octets |   2  |   2   |  2  |   2  |    2   |    2   |     2     |
+//
+//  The Time Zone indicates the difference, expressed in quarters of an hour, between the local time and
+//  GMT. In the first of the two semi-octets, the first bit (bit 3 of the seventh octet of the TP-Service-CentreTime-Stamp
+//  field) represents the algebraic sign of this difference (0 : positive, 1 : negative).
+
 // PDU returns bytes of semi-octet encoded timestamp.
 func (t Timestamp) PDU() []byte {
 	date := time.Time(t)
-	year := uint64(date.Year() - 2000)
-	month := uint64(date.Month())
-	day := uint64(date.Day())
-	hour := uint64(date.Hour())
-	minute := uint64(date.Minute())
-	second := uint64(date.Second())
+	year := date.Year()
+	month := date.Month()
+	day := date.Day()
+	hour := date.Hour()
+	minute := date.Minute()
+	second := date.Second()
+
 	_, offset := date.Zone()
-	quarters := uint64(offset / int(time.Hour/time.Second) * 4)
-	return pdu.EncodeSemi(year, month, day, hour, minute, second, quarters)
+	negativeOffset := offset < 0
+	if negativeOffset {
+		offset = -offset
+	}
+	quarters := offset / int(time.Hour/time.Second) * 4
+
+	_year := pdu.Swap(pdu.Encode((year % 1000)))
+	_month := pdu.Swap(pdu.Encode(int(month)))
+	_day := pdu.Swap(pdu.Encode(day))
+	_hour := pdu.Swap(pdu.Encode(hour))
+	_minute := pdu.Swap(pdu.Encode(minute))
+	_second := pdu.Swap(pdu.Encode(second))
+	_quarters := pdu.Swap(pdu.Encode(quarters))
+	if negativeOffset {
+		_quarters = _quarters | 0x08
+	}
+
+	return []byte{_year, _month, _day, _hour, _minute, _second, _quarters}
 }
 
 // ReadFrom reads a semi-encoded timestamp from the given octets.
 func (t *Timestamp) ReadFrom(octets []byte) {
-	blocks := pdu.DecodeSemi(octets)
-	date := time.Date(2000+blocks[0], time.Month(blocks[1]), blocks[2], blocks[3], blocks[4], blocks[5], 0, time.UTC)
-	diff := time.Duration(blocks[6]) * 15 * time.Minute
-	if blocks[6]>>3&0x01 == 1 { // bit 3 = GMT offset sgn
+	millenium := (time.Now().Year() / 1000) * 1000
+	year := pdu.Decode(pdu.Swap(octets[0]))
+	month := pdu.Decode(pdu.Swap(octets[1]))
+	day := pdu.Decode(pdu.Swap(octets[2]))
+	hour := pdu.Decode(pdu.Swap(octets[3]))
+	minute := pdu.Decode(pdu.Swap(octets[4]))
+	second := pdu.Decode(pdu.Swap(octets[5]))
+
+	negativeOffset := (octets[6] & 0x08) != 0
+	quarters := pdu.Decode(pdu.Swap(octets[6] & 0xF7))
+	offset := time.Duration(quarters) * 15 * time.Minute
+
+	date := time.Date(millenium+year, time.Month(month), day, hour, minute, second, 0, time.UTC)
+
+	if negativeOffset {
 		// was negative, so make UTC
-		date = date.Add(diff)
+		date = date.Add(offset)
 	} else {
 		// was positive, so make UTC
-		date = date.Add(-diff)
+		date = date.Add(-offset)
 	}
 	*t = Timestamp(date.In(time.Local))
 }


### PR DESCRIPTION
relates to issue #11

Datetime in PDU has a fixed structure (see GSM 03.**) and don't need to be procecced with EncodeSemi and DecodeSemi, because occurs the problem with negative time zone offsets. Encoding/Decoding datetime was replaced by a new code. This allowed to solve the problem of incorrect calculation of the time zone offset.

(now correct)