### PR TITLE
fix Alphanumeric coded according to GSM TS 03.38 7-bit default alphabet

### DIFF
--- a/sms/sms.go
+++ b/sms/sms.go
@@ -100,6 +100,18 @@ func (p *PhoneNumber) ReadFrom(octets []byte) {
 		return
 	}
 	addrType := octets[0]
+
+	// Alphanumeric, (coded according to GSM TS 03.38 7-bit default alphabet)
+	if addrType&0x70 == 0x50 {
+		// decode 7 bit
+		addr, err := pdu.Decode7Bit(octets[1:])
+		if err != nil {
+			// handle error, panic or log.Println("Decode7bit", octets, err)
+		}
+		*p = PhoneNumber(addr)
+		return
+	}
+
 	addr := pdu.DecodeSemiAddress(octets[1:])
 	if addrType&0x10 > 0 {
 		*p = PhoneNumber("+" + addr)


### PR DESCRIPTION
This commit fix my problem about wrong phone number:
Eg: 07914889200016F40406D0B11B0C00009120612271858240D17A1EB44687C76810390C4297E9207ABAEC06D1E56FF719445D2E9B20373AEC06D1D36E90FB9D06B5C3EEB30B844DBB41E3701BF4768342

Phone number must be: 170