### PR TITLE
Support single-port modems in Open()

### DIFF
--- a/at.go
+++ b/at.go
@@ -382,6 +382,8 @@ func (d *Device) Open() (err error) {
 			d.cmdPort.Close()
 			return
 		}
+	} else if d.NotifyPort != "" {
+		d.notifyPort = d.cmdPort
 	}
 	return
 }


### PR DESCRIPTION
## Summary

- When `NotifyPort == CommandPort`, alias `notifyPort` to `cmdPort` in `Open()` so that `sanityCheck` passes

## Motivation

Many budget GSM/LTE modems (e.g. SIM800, Quectel EC25 in single-port mode) expose only one serial port. Currently, if `NotifyPort` is set equal to `CommandPort`, `Open()` skips opening the notification port, leaving `notifyPort` as `nil`. This causes `sanityCheck` to return `ErrClosed`, making `Send()` and `Init()` fail.

## Change

In `Open()`, after the dual-port branch, add:

\`\`\`go
} else if d.NotifyPort != "" {
    d.notifyPort = d.cmdPort
}
\`\`\`

This aliases the notification port to the command port fd, allowing `sanityCheck` to pass. Callers should **not** call `Watch()` in this configuration, since reading from the same fd in two goroutines would cause race conditions.

## Backward Compatibility

No behavioral change for existing dual-port configurations. Only affects the case where `NotifyPort == CommandPort`, which previously failed with `ErrClosed`.